### PR TITLE
Accept logger=None

### DIFF
--- a/backoff-stubs/__init__.pyi
+++ b/backoff-stubs/__init__.pyi
@@ -15,7 +15,7 @@ def on_predicate(
     on_success: Optional[_EventHandler] = ...,
     on_backoff: Optional[_EventHandler] = ...,
     on_giveup: Optional[_EventHandler] = ...,
-    logger: Union[str, logging.Logger] = ...,
+    logger: Optional[Union[str, logging.Logger]] = ...,
     **wait_gen_kwargs: Any
 ) -> Callable[[_FuncT], _FuncT]: ...
 
@@ -29,7 +29,7 @@ def on_exception(
     on_success: Optional[_EventHandler] = ...,
     on_backoff: Optional[_EventHandler] = ...,
     on_giveup: Optional[_EventHandler] = ...,
-    logger: Union[str, logging.Logger] = ...,
+    logger: Optional[Union[str, logging.Logger]] = ...,
     **wait_gen_kwargs: Any
 ) -> Callable[[_FuncT], _FuncT]: ...
 


### PR DESCRIPTION
According to the [documentation](https://github.com/litl/backoff#logging-configuration): “Default logging can be disabled all together by specifying `logger=None`. In this case, if desired alternative logging behavior could be defined by using custom event handlers.”