### PR TITLE
chore: Support Python 3.6+

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
-About
-=====
+Backoff Stubs
+=============
 
 This repository contains external type annotations (see `PEP 484 <https://www.python.org/dev/peps/pep-0484/>`_) for the `backoff <https://github.com/litl/backoff>`_ library.
 
@@ -11,3 +11,12 @@ To use these stubs with mypy, you have to install the backoff-stubs package.
 .. code-block:: bash
 
   pip install backoff-stubs
+
+Development
+===========
+
+To contribute to this repository, please fork it on GitHub and open an issue or pull request. You can optionally install dev extras to get the dev tools including tox, flake8, isort, mypy, and types.
+
+.. code-block:: bash
+
+  pip install -e ".[dev]"

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ DIR = Path(__file__).parent
 setup(
     name='backoff-stubs',
     author='Gleb Chipiga',
-    version='1.11.1',
+    version='1.11.2',
     description='External type annotations for the backoff library',
     long_description=(DIR / 'README.rst').read_text('utf-8').strip(),
     long_description_content_type="text/x-rst",
@@ -16,6 +16,9 @@ setup(
         'Intended Audience :: Developers',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3 :: Only',
+        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3.8',
         'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3.10',
@@ -26,11 +29,15 @@ setup(
         'Operating System :: Microsoft :: Windows',
         'Topic :: Internet',
         'Topic :: Software Development :: Libraries',
-        'Topic :: Software Development :: Libraries :: Python Modules'
+        'Topic :: Software Development :: Libraries :: Python Modules',
+        'Typing :: Typed'
     ],
     license='MIT',
     keywords=['retry', 'backoff', 'decorators', 'stubs', 'mypy'],
     packages=['backoff-stubs'],
     package_data={'backoff-stubs': ['__init__.pyi']},
-    python_requires='>=3.8'
+    python_requires='>=3.6,<4.0',
+    extras_require={
+        'dev': ['flake8', 'isort', 'mypy', 'types-setuptools', 'tox', 'twine'],
+    }
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py38,py39,py310
+envlist = py36,py37,py38,py39,py310
 
 [testenv]
 deps =


### PR DESCRIPTION
Hi there,

I really appreciate this project, however it was causing some issues for my projects that support Python 3.6 and Python 3.7. I hope you don't mind this PR to include both in the `tox.ini` and `setup.py:python_requires`. 

Thanks again,
Aidan